### PR TITLE
2 changes done in this commit for android platform Gradle dependency.

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -7,5 +7,5 @@ android {
 }
 
 dependencies {
-	compile 'org.altbeacon:android-beacon-library:2.9.2'
+	implementation 'org.altbeacon:android-beacon-library:2.19.5'
 }


### PR DESCRIPTION
In this PR 2 changes done for android platform 
1.Gradle dependency method compile to implementation.
2.beacon-library version 2.9.2 to 2.19.5.